### PR TITLE
PIP-407: Added support for key removal within a group

### DIFF
--- a/peers.go
+++ b/peers.go
@@ -30,6 +30,7 @@ type Context interface{}
 // ProtoGetter is the interface that must be implemented by a peer.
 type ProtoGetter interface {
 	Get(context Context, in *pb.GetRequest, out *pb.GetResponse) error
+	Remove(context Context, in *pb.GetRequest) error
 }
 
 // PeerPicker is the interface that must be implemented to locate
@@ -39,12 +40,14 @@ type PeerPicker interface {
 	// and true to indicate that a remote peer was nominated.
 	// It returns nil, false if the key owner is the current peer.
 	PickPeer(key string) (peer ProtoGetter, ok bool)
+	GetAll() []ProtoGetter
 }
 
 // NoPeers is an implementation of PeerPicker that never finds a peer.
 type NoPeers struct{}
 
 func (NoPeers) PickPeer(key string) (peer ProtoGetter, ok bool) { return }
+func (NoPeers) GetAll() []ProtoGetter                           { return []ProtoGetter{} }
 
 var (
 	portPicker func(groupName string) PeerPicker

--- a/singleflight/singleflight.go
+++ b/singleflight/singleflight.go
@@ -62,3 +62,12 @@ func (g *Group) Do(key string, fn func() (interface{}, error)) (interface{}, err
 
 	return c.val, c.err
 }
+
+// Lock prevents single flights from occurring for the duration
+// of the provided function. This allows users to clear caches
+// or preform some operation in between running flights.
+func (g *Group) Lock(fn func()) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	fn()
+}


### PR DESCRIPTION
## Purpose
Allows users to delete keys from the groupcache were the deletion operation will be propagated to other peers in the group.

## Implementation
* Deletes the key from the owner first then deletes key from each peer