### PR TITLE
Release Candidate 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,9 @@ script:
   - go test ./...
 
 go:
-  - 1.9.x
   - 1.10.x
   - 1.11.x
+  - 1.12.x
   - master
 
 cache:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,23 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2019-05-30
+### Changes
+* Now using golang standard `context.Context` instead of groupcache.Context.
+* http requests now respect `context.Context` done.
+
+## [1.3.0] - 2019-05-23
+### Added
+* Added `Remove()` method to `Group` to purge a key from the group.
+
+## [1.1.0] - 2019-04-10
+### Added
+* Sinks can now accept an expire time
+* Changed import path to mailgun/groupcache
+
+## [hash 5b532d6fd5efaf7fa130d4e859a2fde0fc3a9e1b] - 2019-01-29
+### Changes
+* Initial import from https://github.com/golang/groupcache

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,8 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.0.0] - 2019-05-30
 ### Changes
-* Now using golang standard `context.Context` instead of groupcache.Context.
-* http requests now respect `context.Context` done.
+* Now using golang standard `context.Context` instead of `groupcache.Context`.
+* HTTP requests made by `httpGetter` now respect `context.Context` done.
+* Moved `HTTPPool` config `Context` and `Transport` to `HTTPPoolOptions` for consist configuration.
+* Now Associating the transport with peer `httpGetter` so we take advantage of
+  connection reuse.  This lowers the impact on DNS and improves performance for
+  high request volume low latency applications.
+* Now always populating the hotcache. A more complex algorithm is unnecessary
+  when the LRU cache will ensure the most used values remain in the cache. The
+  evict code ensures the hotcache does not overcrowd the maincache.
 
 ## [1.3.0] - 2019-05-23
 ### Added

--- a/groupcache.go
+++ b/groupcache.go
@@ -25,6 +25,7 @@ limitations under the License.
 package groupcache
 
 import (
+	"context"
 	"errors"
 	"math/rand"
 	"strconv"
@@ -45,13 +46,13 @@ type Getter interface {
 	// uniquely describe the loaded data, without an implicit
 	// current time, and without relying on cache expiration
 	// mechanisms.
-	Get(ctx Context, key string, dest Sink) error
+	Get(ctx context.Context, key string, dest Sink) error
 }
 
 // A GetterFunc implements Getter with a function.
-type GetterFunc func(ctx Context, key string, dest Sink) error
+type GetterFunc func(ctx context.Context, key string, dest Sink) error
 
-func (f GetterFunc) Get(ctx Context, key string, dest Sink) error {
+func (f GetterFunc) Get(ctx context.Context, key string, dest Sink) error {
 	return f(ctx, key, dest)
 }
 
@@ -210,7 +211,7 @@ func (g *Group) initPeers() {
 	}
 }
 
-func (g *Group) Get(ctx Context, key string, dest Sink) error {
+func (g *Group) Get(ctx context.Context, key string, dest Sink) error {
 	g.peersOnce.Do(g.initPeers)
 	g.Stats.Gets.Add(1)
 	if dest == nil {
@@ -240,7 +241,7 @@ func (g *Group) Get(ctx Context, key string, dest Sink) error {
 
 // Remove clears the key from our cache then forwards the remove
 // request to all peers.
-func (g *Group) Remove(ctx Context, key string) error {
+func (g *Group) Remove(ctx context.Context, key string) error {
 	g.peersOnce.Do(g.initPeers)
 
 	_, err := g.removeGroup.Do(key, func() (interface{}, error) {
@@ -288,7 +289,7 @@ func (g *Group) Remove(ctx Context, key string) error {
 }
 
 // load loads key either by invoking the getter locally or by sending it to another machine.
-func (g *Group) load(ctx Context, key string, dest Sink) (value ByteView, destPopulated bool, err error) {
+func (g *Group) load(ctx context.Context, key string, dest Sink) (value ByteView, destPopulated bool, err error) {
 	g.Stats.Loads.Add(1)
 	viewi, err := g.loadGroup.Do(key, func() (interface{}, error) {
 		// Check the cache again because singleflight can only dedup calls
@@ -347,7 +348,7 @@ func (g *Group) load(ctx Context, key string, dest Sink) (value ByteView, destPo
 	return
 }
 
-func (g *Group) getLocally(ctx Context, key string, dest Sink) (ByteView, error) {
+func (g *Group) getLocally(ctx context.Context, key string, dest Sink) (ByteView, error) {
 	err := g.getter.Get(ctx, key, dest)
 	if err != nil {
 		return ByteView{}, err
@@ -355,7 +356,7 @@ func (g *Group) getLocally(ctx Context, key string, dest Sink) (ByteView, error)
 	return dest.view()
 }
 
-func (g *Group) getFromPeer(ctx Context, peer ProtoGetter, key string) (ByteView, error) {
+func (g *Group) getFromPeer(ctx context.Context, peer ProtoGetter, key string) (ByteView, error) {
 	req := &pb.GetRequest{
 		Group: &g.name,
 		Key:   &key,
@@ -384,7 +385,7 @@ func (g *Group) getFromPeer(ctx Context, peer ProtoGetter, key string) (ByteView
 	return value, nil
 }
 
-func (g *Group) removeFromPeer(ctx Context, peer ProtoGetter, key string) error {
+func (g *Group) removeFromPeer(ctx context.Context, peer ProtoGetter, key string) error {
 	req := &pb.GetRequest{
 		Group: &g.name,
 		Key:   &key,

--- a/groupcache.go
+++ b/groupcache.go
@@ -27,7 +27,6 @@ package groupcache
 import (
 	"context"
 	"errors"
-	"math/rand"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -376,12 +375,9 @@ func (g *Group) getFromPeer(ctx context.Context, peer ProtoGetter, key string) (
 	}
 
 	value := ByteView{b: res.Value, e: expire}
-	// TODO(bradfitz): use res.MinuteQps or something smart to
-	// conditionally populate hotCache.  For now just do it some
-	// percentage of the time.
-	if rand.Intn(10) == 0 {
-		g.populateCache(key, value, &g.hotCache)
-	}
+
+	// Always populate the hot cache
+	g.populateCache(key, value, &g.hotCache)
 	return value, nil
 }
 

--- a/groupcache_test.go
+++ b/groupcache_test.go
@@ -23,7 +23,6 @@ import (
 	"errors"
 	"fmt"
 	"hash/crc32"
-	"math/rand"
 	"reflect"
 	"sync"
 	"testing"
@@ -33,7 +32,7 @@ import (
 	"github.com/golang/protobuf/proto"
 
 	pb "github.com/mailgun/groupcache/groupcachepb"
-	testpb "github.com/mailgun/groupcache/testpb"
+	"github.com/mailgun/groupcache/testpb"
 )
 
 var (
@@ -289,7 +288,6 @@ func (p fakePeers) GetAll() []ProtoGetter {
 // tests that peers (virtual, in-process) are hit, and how much.
 func TestPeers(t *testing.T) {
 	once.Do(testSetup)
-	rand.Seed(123)
 	peer0 := &fakePeer{}
 	peer1 := &fakePeer{}
 	peer2 := &fakePeer{}
@@ -339,9 +337,9 @@ func TestPeers(t *testing.T) {
 	resetCacheSize(1 << 20)
 	run("base", 200, "localHits = 49, peers = 51 49 51")
 
-	// Verify cache was hit.  All localHits are gone, and some of
-	// the peer hits (the ones randomly selected to be maybe hot)
-	run("cached_base", 200, "localHits = 0, peers = 49 47 48")
+	// Verify cache was hit.  All localHits and peers are gone as the hotCache has
+	// the data we need
+	run("cached_base", 200, "localHits = 0, peers = 0 0 0")
 	resetCacheSize(0)
 
 	// With one of the peers being down.

--- a/http_test.go
+++ b/http_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package groupcache
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -96,7 +97,7 @@ func TestHTTPPool(t *testing.T) {
 	// Dummy getter function. Gets should go to children only.
 	// The only time this process will handle a get is when the
 	// children can't be contacted for some reason.
-	getter := GetterFunc(func(ctx Context, key string, dest Sink) error {
+	getter := GetterFunc(func(ctx context.Context, key string, dest Sink) error {
 		return errors.New("parent getter called; something's wrong")
 	})
 	g := NewGroup("httpPoolTest", 1<<20, getter)
@@ -162,7 +163,7 @@ func beChildForTestHTTPPool(t *testing.T) {
 	p := NewHTTPPool("http://" + addrs[*peerIndex])
 	p.Set(addrToURL(addrs)...)
 
-	getter := GetterFunc(func(ctx Context, key string, dest Sink) error {
+	getter := GetterFunc(func(ctx context.Context, key string, dest Sink) error {
 		if _, err := http.Get(*serverAddr); err != nil {
 			t.Logf("HTTP request from getter failed with '%s'", err)
 		}

--- a/peers.go
+++ b/peers.go
@@ -19,18 +19,14 @@ limitations under the License.
 package groupcache
 
 import (
+	"context"
 	pb "github.com/mailgun/groupcache/groupcachepb"
 )
 
-// Context is an opaque value passed through calls to the
-// ProtoGetter. It may be nil if your ProtoGetter implementation does
-// not require a context.
-type Context interface{}
-
 // ProtoGetter is the interface that must be implemented by a peer.
 type ProtoGetter interface {
-	Get(context Context, in *pb.GetRequest, out *pb.GetResponse) error
-	Remove(context Context, in *pb.GetRequest) error
+	Get(context context.Context, in *pb.GetRequest, out *pb.GetResponse) error
+	Remove(context context.Context, in *pb.GetRequest) error
 }
 
 // PeerPicker is the interface that must be implemented to locate


### PR DESCRIPTION
## [2.0.0] - 2019-05-30
### Changes
* Now using golang standard `context.Context` instead of `groupcache.Context`.
* HTTP requests made by `httpGetter` now respect `context.Context` done.
* Moved `HTTPPool` config `Context` and `Transport` to `HTTPPoolOptions` for consist configuration.
* Now Associating the transport with peer `httpGetter` so there is no need to
  call `Transport` function for each request.
* Now always populating the hotcache. A more complex algorithm is unnecessary
  when the LRU cache will ensure the most used values remain in the cache. The
  evict code ensures the hotcache does not overcrowd the maincache.