### PR TITLE
Fix HTTPPoolOptions.Transport 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,18 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0-rc.2] - 2019-06-03
+## [2.0.0-rc.3] - 2019-06-03
 ### Changes
 * Now using golang standard `context.Context` instead of `groupcache.Context`.
 * HTTP requests made by `httpGetter` now respect `context.Context` done.
 * Moved `HTTPPool` config `Context` and `Transport` to `HTTPPoolOptions` for consist configuration.
-* Now Associating the transport with peer `httpGetter` so we take advantage of
-  connection reuse.  This lowers the impact on DNS and improves performance for
-  high request volume low latency applications.
+* Now Associating the transport with peer `httpGetter` so there is no need to
+  call `Transport` function for each request.
 * Now always populating the hotcache. A more complex algorithm is unnecessary
   when the LRU cache will ensure the most used values remain in the cache. The
   evict code ensures the hotcache does not overcrowd the maincache.
 * Changed import paths to /v2 in accordance with go modules rules
+* Fixed Issue where `DefaultTransport` was always used even if `Transport` was
+  specified by the user.
 
 ## [1.3.0] - 2019-05-23
 ### Added


### PR DESCRIPTION
## [2.0.0-rc.3] - 2019-06-03
### Changes
* Fixed Issue where `DefaultTransport` was always used even if `Transport` was specified by the user.
