### PR TITLE
Consistent hash improvements

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2021-01-13
+### Changes
+* Now uses the much faster fnv1
+* Now md5 hashs the keys to help distribute hosts more evenly in some
+  cases.
+
 ## [2.2.0] - 2019-07-09
 ### Added
 * Added `SetLogger()` to pass in a logrus entry for logging peer errors

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/mailgun/groupcache/v2
 
 require (
 	github.com/golang/protobuf v1.3.1
+	github.com/segmentio/fasthash v1.0.3
 	github.com/sirupsen/logrus v1.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -12,3 +12,5 @@ github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894 h1:Cz4ceDQGXuKRnVBDTS23GTn/pU5OE2C0WrNTOYK1Uuc=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+github.com/segmentio/fasthash v1.0.3 h1:EI9+KE1EwvMLBWwjpRDc+fEM+prwxDYbslddQGtrmhM=
+github.com/segmentio/fasthash v1.0.3/go.mod h1:waKX8l2N8yckOgmSsXJi7x1ZfdKZ4x7KRMzBtS3oedY=


### PR DESCRIPTION
* Now uses the much faster fnv1
* Now md5 hashs the keys to help distribute hosts more evenly in some
  cases.