### PR TITLE
Make LocalRemove public

### DIFF
--- a/groupcache.go
+++ b/groupcache.go
@@ -301,7 +301,7 @@ func (g *Group) Remove(ctx context.Context, key string) error {
 			}
 		}
 		// Remove from our cache next
-		g.localRemove(key)
+		g.LocalRemove(key)
 		wg := sync.WaitGroup{}
 		errs := make(chan error)
 
@@ -508,7 +508,9 @@ func (g *Group) localSet(key string, value []byte, expire time.Time, cache *cach
 	})
 }
 
-func (g *Group) localRemove(key string) {
+// LocalRemove key from the local cache
+// This method is only intended to be used by groupcache.ProtoGetter implementors
+func (g *Group) LocalRemove(key string) {
 	// Clear key from our local cache
 	if g.cacheBytes <= 0 {
 		return

--- a/http.go
+++ b/http.go
@@ -188,7 +188,7 @@ func (p *HTTPPool) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	// Delete the key and return 200
 	if r.Method == http.MethodDelete {
-		group.localRemove(key)
+		group.LocalRemove(key)
 		return
 	}
 


### PR DESCRIPTION
When implementing `groupcache.ProtoGetter`, calling `Group.Remove` is not an option as it would recursively resend the removal request to other peers. In the HTTP transport the private method `localRemove` is used to prevent such issue, but this would make out of package alternative transport (we're using gRPC) implementation impossible.

Arguably, making this private API public would make it misuse-prone, but I believe other than shipping all possible transports, there's no alternative. Unlike `Get`, `Remove` needs to be fired on *all* nodes so the terminating cause wouldn't be the same as `Get`.

I'm open to open sourcing our gRPC peer picker as well, if this upstream would accept it.