### PR TITLE
fix: deal with panics in Getter.Get

### DIFF
--- a/singleflight/singleflight.go
+++ b/singleflight/singleflight.go
@@ -18,7 +18,10 @@ limitations under the License.
 // mechanism.
 package singleflight
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
 // call is an in-flight or completed Do call
 type call struct {
@@ -48,17 +51,22 @@ func (g *Group) Do(key string, fn func() (interface{}, error)) (interface{}, err
 		c.wg.Wait()
 		return c.val, c.err
 	}
-	c := new(call)
+	c := &call{
+		err: fmt.Errorf("singleflight leader panicked"),
+	}
 	c.wg.Add(1)
 	g.m[key] = c
 	g.mu.Unlock()
 
-	c.val, c.err = fn()
-	c.wg.Done()
+	defer func() {
+		c.wg.Done()
 
-	g.mu.Lock()
-	delete(g.m, key)
-	g.mu.Unlock()
+		g.mu.Lock()
+		delete(g.m, key)
+		g.mu.Unlock()
+	}()
+
+	c.val, c.err = fn()
 
 	return c.val, c.err
 }


### PR DESCRIPTION
This is a first attempt at better dealing with panics inside `Getter.Get`.

fixes #38 