### PR TITLE
feat: do not count context cancelation as peer error

### DIFF
--- a/groupcache.go
+++ b/groupcache.go
@@ -386,6 +386,9 @@ func (g *Group) load(ctx context.Context, key string, dest Sink) (value ByteView
 			if err == nil {
 				g.Stats.PeerLoads.Add(1)
 				return value, nil
+			} else if errors.Is(err, context.Canceled) {
+				// do not count context cancellation as a peer error
+				return nil, err
 			}
 
 			if logger != nil {


### PR DESCRIPTION
If the incoming internal groupcache request gets canceled, it should not count as a peer error.

With the current code, it's impossible to separate context cancelations (which might be outside the control of the service running groupcache) from "real" peer errors.

Also, with this PR, in case the internal request times-out (via `context`), the requesting peer can still do its own error accounting.

WDYT?