### PR TITLE
Add HTTP error message from peer to error returned from httpGetter.Get

### DIFF
--- a/http.go
+++ b/http.go
@@ -299,7 +299,8 @@ func (h *httpGetter) Get(ctx context.Context, in *pb.GetRequest, out *pb.GetResp
 	}
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
-		return fmt.Errorf("server returned: %v", res.Status)
+		msg, _ := ioutil.ReadAll(io.LimitReader(res.Body, 10*1024*1024)) // Limit reading the error body to max 10 MiB
+		return fmt.Errorf("server returned: %v, %v", res.Status, msg)
 	}
 	b := bufferPool.Get().(*bytes.Buffer)
 	b.Reset()


### PR DESCRIPTION
Currently errors returned when making requests to peers only contain the status code returned by the peer. Most of the time this will be a 500 error. The real error reason is returned by the peer in the response body.

This PR adds the error message from the peer to the error returned by the `httpGetter.Get` method. I've limited the error message to max 10 MiB to limit to prevent possible chaos when peers start returning errors of multiple GB's or something 😃.