### PR TITLE
Link to v2 docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ modifications.
 groupcache is a caching and cache-filling library, intended as a
 replacement for memcached in many cases.
 
-For API docs and examples, see http://godoc.org/github.com/mailgun/groupcache
+For API docs and examples, see http://godoc.org/github.com/mailgun/groupcache/v2
 
    
 ### Modifications from original library


### PR DESCRIPTION
The README links to the v1 docs, which is confusing when the examples use v2