### PR TITLE
Use PathEscape instead of QueryEscape in httpGetter

### DIFF
--- a/http.go
+++ b/http.go
@@ -271,8 +271,8 @@ func (h *httpGetter) makeRequest(ctx context.Context, m string, in request, b io
 	u := fmt.Sprintf(
 		"%v%v/%v",
 		h.baseURL,
-		url.QueryEscape(in.GetGroup()),
-		url.QueryEscape(in.GetKey()),
+		url.PathEscape(in.GetGroup()),
+		url.PathEscape(in.GetKey()),
 	)
 	req, err := http.NewRequestWithContext(ctx, m, u, b)
 	if err != nil {
@@ -300,7 +300,7 @@ func (h *httpGetter) Get(ctx context.Context, in *pb.GetRequest, out *pb.GetResp
 	defer res.Body.Close()
 	if res.StatusCode != http.StatusOK {
 		msg, _ := ioutil.ReadAll(io.LimitReader(res.Body, 1024*1024)) // Limit reading the error body to max 1 MiB
-		return fmt.Errorf("server returned: %v, %v", res.Status, msg)
+		return fmt.Errorf("server returned: %v, %v", res.Status, string(msg))
 	}
 	b := bufferPool.Get().(*bytes.Buffer)
 	b.Reset()

--- a/http_test.go
+++ b/http_test.go
@@ -174,6 +174,15 @@ func TestHTTPPool(t *testing.T) {
 	if !bytes.Equal(setValue, getValue.ByteSlice()) {
 		t.Fatal(errors.New(fmt.Sprintf("incorrect value retrieved after set: %s", getValue)))
 	}
+
+	// Key with non-URL characters to test URL encoding roundtrip
+	key = "a b/c,d"
+	if err := g.Get(ctx, key, StringSink(&value)); err != nil {
+		t.Fatal(err)
+	}
+	if suffix := ":" + key; !strings.HasSuffix(value, suffix) {
+		t.Errorf("Get(%q) = %q, want value ending in %q", key, value, suffix)
+	}
 }
 
 func testKeys(n int) (keys []string) {


### PR DESCRIPTION
Just a couple of small fixes to http.go:
* Use `PathEscape` instead of `QueryEscape` for building request URLs. The HTTP handler uses `PathUnescape` so this roundtrips keys containing space characters correctly.
* Convert error message from `[]byte` to `string`.