### PR TITLE
Fix not update `entry.expire` in `cache`

### DIFF
--- a/lru/lru.go
+++ b/lru/lru.go
@@ -64,7 +64,11 @@ func (c *Cache) Add(key Key, value interface{}, expire time.Time) {
 	}
 	if ee, ok := c.cache[key]; ok {
 		c.ll.MoveToFront(ee)
-		ee.Value.(*entry).value = value
+		entry := ee.Value.(*entry)
+		entry.value = value
+		if !expire.IsZero() && expire.After(time.Now()) {
+			entry.expire = expire
+		}
 		return
 	}
 	ele := c.ll.PushFront(&entry{key, value, expire})


### PR DESCRIPTION
`cache.Add` function doesn't update the entry `entry.expire` if exists an entry.
but `entry.value` already does update.

https://github.com/mailgun/groupcache/blob/df5395112d7caeaf6ee14e333953bb563c21b0ba/lru/lru.go#L65-L69

This PR also does update `entry.expire`.