### PR TITLE
fix cache size on updating value

### DIFF
--- a/groupcache_test.go
+++ b/groupcache_test.go
@@ -553,7 +553,7 @@ func TestCacheUpdateValue(t *testing.T) {
 		t.Errorf("Invalid buffer size: %d, must be %d", c.bytes(), expectedSize)
 	}
 
-	bw2 := ByteView{s: "mySecondValue", e: time.Now().Add(100 * time.Second)}
+	bw2 := ByteView{s: "mySecondValue", e: time.Now().Add(200 * time.Second)}
 	expectedSize = expectedSize - getItemSize(myKey, bw1) + getItemSize(myKey, bw2)
 	c.add(myKey, bw2)
 	v, ok = c.get(myKey)

--- a/groupcache_test.go
+++ b/groupcache_test.go
@@ -535,3 +535,35 @@ func TestContextDeadlineOnPeer(t *testing.T) {
 		}
 	}
 }
+
+func TestCacheUpdateValue(t *testing.T) {
+	c := &cache{}
+	myKey := "myKey"
+	bw1 := ByteView{s: "myFirstValue", e: time.Now().Add(100 * time.Second)}
+	expectedSize := getItemSize(myKey, bw1)
+	c.add(myKey, bw1)
+	v, ok := c.get(myKey)
+	if !ok {
+		t.Error("Key not found after adding")
+	}
+	if !v.Equal(bw1) {
+		t.Error("Added key differs from got")
+	}
+	if c.bytes() != expectedSize {
+		t.Errorf("Invalid buffer size: %d, must be %d", c.bytes(), expectedSize)
+	}
+
+	bw2 := ByteView{s: "mySecondValue", e: time.Now().Add(100 * time.Second)}
+	expectedSize = expectedSize - getItemSize(myKey, bw1) + getItemSize(myKey, bw2)
+	c.add(myKey, bw2)
+	v, ok = c.get(myKey)
+	if !ok {
+		t.Error("Key not found after second adding")
+	}
+	if !v.Equal(bw2) {
+		t.Error("Added key differs from got")
+	}
+	if c.bytes() != expectedSize {
+		t.Errorf("Invalid buffer size: %d, must be %d", c.bytes(), expectedSize)
+	}
+}

--- a/lru/lru_test.go
+++ b/lru/lru_test.go
@@ -121,3 +121,23 @@ func TestExpire(t *testing.T) {
 		}
 	}
 }
+
+func TestReplacement(t *testing.T) {
+	replacedKeys := make([]Key, 0)
+	onReplacementFunc := func(key Key, value interface{}, expire time.Time) {
+		replacedKeys = append(replacedKeys, key)
+	}
+
+	lru := New(2)
+	lru.OnReplace = onReplacementFunc
+	for i := 0; i < 3; i++ {
+		lru.Add(fmt.Sprintf("myKey%d", i%2), 1234, time.Time{})
+	}
+
+	if len(replacedKeys) != 1 {
+		t.Fatalf("got %d evicted keys; want 1", len(replacedKeys))
+	}
+	if replacedKeys[0] != Key("myKey0") {
+		t.Fatalf("got %v in first evicted key; want %s", replacedKeys[0], "myKey0")
+	}
+}


### PR DESCRIPTION
Fix couple of bugs:
1. if update value in cache, cache size will increase on size of new value instead of difference between previous and new one;
2. if update value in cache, expiration time won't change