### PR TITLE
Improve HTTP error handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# 
+# This change log is deprecated in favor of github release functionality.
+# See https://github.com/mailgun/groupcache/releases for recent change activity.
+
 ## [2.3.1] - 2022-05-17
 ### Changed
 * Fix example in README #40

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,33 @@
+package groupcache
+
+// ErrNotFound should be returned from an implementation of `GetterFunc` to indicate the
+// requested value is not available. When remote HTTP calls are made to retrieve values from
+// other groupcache instances, returning this error will indicate to groupcache that the
+// value requested is not available, and it should NOT attempt to call `GetterFunc` locally.
+type ErrNotFound struct {
+	Msg string
+}
+
+func (e *ErrNotFound) Error() string {
+	return e.Msg
+}
+
+func (e *ErrNotFound) Is(target error) bool {
+	_, ok := target.(*ErrNotFound)
+	return ok
+}
+
+// ErrRemoteCall is returned from `group.Get()` when an error that is not a `ErrNotFound`
+// is returned during a remote HTTP instance call
+type ErrRemoteCall struct {
+	Msg string
+}
+
+func (e *ErrRemoteCall) Error() string {
+	return e.Msg
+}
+
+func (e *ErrRemoteCall) Is(target error) bool {
+	_, ok := target.(*ErrRemoteCall)
+	return ok
+}


### PR DESCRIPTION
### Purpose
To improve how we report errors when making HTTP calls to other `groupcache` instances. See #59 for details on the proposal.

### Implementation
* Added `groupcache.ErrNotFound` which should be returned from an implementation of `GetterFunc` to indicate the requested value is not available
* Added `groupcache.ErrRemoteCall`  which is returned from `group.Get()` when an error that is not a `ErrNotFound` is returned during a remote HTTP instance call